### PR TITLE
Add micromamba installation, update vars to include region and use this for volume creation

### DIFF
--- a/AnsibleSlurmCluster/playbooks/common.yml
+++ b/AnsibleSlurmCluster/playbooks/common.yml
@@ -22,3 +22,4 @@
   roles:
     - common
     - singularity
+    - micromamba

--- a/AnsibleSlurmCluster/roles/conda_env/defaults/main.yml
+++ b/AnsibleSlurmCluster/roles/conda_env/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+# Defaults for conda environment management variables (overwrite during role inclusion)
+
+# Install micromamba as conda provider by default
+conda_env_install_micromamba: true
+# Conda executable (path or command).
+#   Will be set to micromamba in case `conda_env_install_micromamba` is enabled
+conda_exe: "{{ 'conda' if not conda_env_install_micromamba else micromamba_destination }}"
+# The specification file for the Conda environment (required)
+conda_env_spec_file: null
+# Optional: The prefix for the Conda environment
+conda_prefix: null
+# Optional: The name of the Conda environment
+conda_env_name: null

--- a/AnsibleSlurmCluster/roles/conda_env/meta/main.yml
+++ b/AnsibleSlurmCluster/roles/conda_env/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+ - role: 'micromamba'
+   when: conda_env_install_micromamba

--- a/AnsibleSlurmCluster/roles/conda_env/tasks/main.yml
+++ b/AnsibleSlurmCluster/roles/conda_env/tasks/main.yml
@@ -1,0 +1,88 @@
+---
+- name: Ensure required variables are defined
+  fail:
+    msg: "The required variable '{{ item }}' is not defined."
+  with_items:
+    - conda_exe
+    - conda_env_spec_file
+  when: item is not defined
+
+- name: Check if prefix is a valid conda environment
+  ansible.builtin.shell: >-
+    {{ conda_exe }} list
+    {% if conda_prefix | default(False) %}
+    --prefix "{{ conda_prefix }}"
+    {% endif %}
+    {% if conda_env_name | default(False) %}
+    --name "{{ conda_env_name }}"
+    {% endif %}
+    --json
+  register: conda_list_output
+  ignore_errors: true  # Allow the task to continue even if the prefix is invalid
+  changed_when: false  # Always assume this task does not make changes
+
+- name: Parse conda output
+  ansible.builtin.set_fact:
+    is_valid_env: >-
+      {{
+        conda_list_output.rc == 0 and
+        conda_list_output.stdout | from_json | length > 0
+      }}
+
+- name: Install environment
+  when: not is_valid_env
+  ansible.builtin.shell: >-
+    {{ conda_exe }} env create
+    --file {{ conda_env_spec_file }}
+    {% if conda_prefix | default(False) %}
+    --prefix "{{ conda_prefix }}"
+    {% endif %}
+    {% if conda_env_name | default(False) %}
+    --name "{{ conda_env_name }}"
+    {% endif %}
+    --json
+    -y
+  register: conda_env_update_output
+  changed_when: >
+    conda_env_update_output.stdout | from_json | json_query('actions') is defined
+
+
+- name: Update environment
+  when: is_valid_env
+  block:
+    - name: Run "conda env update" to match the environment to the spec file
+      ansible.builtin.shell: >-
+        {{ conda_exe }} env update
+        --file {{ conda_env_spec_file }}
+        {% if conda_prefix | default(False) %}
+        --prefix "{{ conda_prefix }}"
+        {% endif %}
+        {% if conda_env_name | default(False) %}
+        --name "{{ conda_env_name }}"
+        {% endif %}
+        --json
+        -y
+      register: cmd_output
+      changed_when: >
+        cmd_output.stdout | from_json | json_query('actions') is defined
+      failed_when: >
+        cmd_output.rc != 0 or
+        (cmd_output.stdout | from_json).success == false
+    - name: Run "conda update" to update packages within the environment
+      ansible.builtin.shell: >-
+        {{ conda_exe }} update
+        --file {{ conda_env_spec_file }}
+        {% if conda_prefix | default(False) %}
+        --prefix "{{ conda_prefix }}"
+        {% endif %}
+        {% if conda_env_name | default(False) %}
+        --name "{{ conda_env_name }}"
+        {% endif %}
+        --json
+        -y
+      register: cmd_output
+      changed_when: >
+        cmd_output.stdout | from_json | json_query('actions') is defined
+      failed_when: >-
+        cmd_output.rc != 0 or
+        (cmd_output.stdout | from_json).success == false

--- a/AnsibleSlurmCluster/roles/micromamba/README.md
+++ b/AnsibleSlurmCluster/roles/micromamba/README.md
@@ -1,0 +1,44 @@
+# Micromamba Ansible Role
+
+This Ansible role installs and configures micromamba, a lightweight and fast package manager for conda environments.
+
+## Requirements
+
+* Ansible 2.9 or later
+
+## Role Variables
+
+The following variables are available to customize the role:
+
+* `micromamba_destination`: The path where micromamba will be installed. <br>
+    Default: `conda_exe` if defined, otherwide `/usr/local/bin/micromamba`
+* `micromamba_version`: The version of micromamba to be installed. <br>
+    Default: "latest"
+
+
+## Example
+
+
+### In playbook
+
+Here is an example playbook that uses this role:
+```yaml
+---
+- name: Install micromamba
+  hosts: all
+  become: true
+  roles:
+    - micromamba
+  vars:
+    conda_exe: "/usr/local/bin/micromamba"
+```
+
+### As dependency
+This role can be used as dependency in other roles:
+```yaml
+---
+dependencies:
+ - role: 'micromamba'
+   when: install_micromamba
+```
+This role will conveniently export `conda_exe` to the `micromamba_destination` if it was not specified by higher priority variables (e.g. group or host variables).

--- a/AnsibleSlurmCluster/roles/micromamba/defaults/main.yml
+++ b/AnsibleSlurmCluster/roles/micromamba/defaults/main.yml
@@ -1,0 +1,3 @@
+micromamba_version: latest
+micromamba_destination: '/usr/local/bin/micromamba'
+micromamba_base_env_prefix: '/opt/conda_envs'

--- a/AnsibleSlurmCluster/roles/micromamba/tasks/main.yml
+++ b/AnsibleSlurmCluster/roles/micromamba/tasks/main.yml
@@ -1,0 +1,76 @@
+---
+- name: "Check if micromamba already exists"
+  ansible.builtin.stat:
+    path: "{{ micromamba_destination }}"
+    get_checksum: true
+    checksum_algorithm: "sha256"
+    follow: true
+  register: micromamba_dest_stat
+
+- name: Map platform to value
+  ansible.builtin.set_fact:
+    micromamba_platform: "{{ micromamba_platform_mapping[ansible_system][ansible_machine] | default('unknown-platform') }}"
+
+- name: Fail if platform is unsupported
+  ansible.builtin.fail:
+    msg: >
+      "Unsupported platform: {{ ansible_system }} {{ ansible_machine }}. 
+       Please update micromamba_platform_mapping."
+  when: micromamba_platform == "unknown-platform"
+
+- name: Construct the micromamba URL
+  ansible.builtin.set_fact:
+    micromamba_url: "{{ micromamba_base_url }}"
+  vars:
+    platform: "{{ micromamba_platform }}"
+
+- name: Construct the micromamba SHA256 URL
+  ansible.builtin.set_fact:
+    micromamba_sha256_url: "{{ micromamba_sha256_base_url }}"
+  vars:
+    platform: "{{ micromamba_platform }}"
+
+- name: Fetch SHA256 checksum
+  ansible.builtin.uri:
+    url: "{{ micromamba_sha256_url }}"
+    return_content: yes
+  register: sha256_checksum
+
+# install micromamba
+- name: Install micromamba
+  ansible.builtin.get_url:
+    url: "{{ micromamba_url }}"
+    dest: "{{ micromamba_destination }}"
+    checksum: sha256:{{ sha256_checksum.content }}
+    mode: '0755'
+  register: result
+  until: result is succeeded
+  retries: 3
+  delay: 10
+  when: not micromamba_dest_stat.stat.exists or micromamba_dest_stat.stat.checksum != sha256_checksum.content
+
+- name: Export micromamba_destination
+  ansible.builtin.set_fact:
+    conda_exe: "{{ micromamba_destination }}"
+  when: conda_exe is not defined
+
+- name: Ensure micromamba_init.sh exists with correct content
+  copy:
+    dest: /etc/profile.d/micromamba_init.sh
+    content: |
+      eval $({{ micromamba_destination }} shell hook --root-prefix {{ micromamba_base_env_prefix }} --shell=$(basename $SHELL))
+      # >>> mamba initialize >>>
+      # !! Contents within this block are managed by 'micromamba shell init' !!
+      export MAMBA_EXE='{{ micromamba_destination }}';
+      export MAMBA_ROOT_PREFIX='{{ micromamba_base_env_prefix }}';
+      __mamba_setup="$("$MAMBA_EXE" shell hook --shell bash --root-prefix "$MAMBA_ROOT_PREFIX" 2> /dev/null)"
+      if [ $? -eq 0 ]; then
+          eval "$__mamba_setup"
+      else
+          alias micromamba="$MAMBA_EXE"  # Fallback on help from micromamba activate
+      fi
+      unset __mamba_setup
+      # <<< mamba initialize <<<
+    owner: root
+    group: root
+    mode: '0644'

--- a/AnsibleSlurmCluster/roles/micromamba/vars/main.yml
+++ b/AnsibleSlurmCluster/roles/micromamba/vars/main.yml
@@ -1,0 +1,13 @@
+micromamba_base_url: "https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-{{ platform }}"
+micromamba_sha256_base_url: "https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-{{ platform }}.sha256"
+
+micromamba_platform_mapping:
+  Linux:
+    x86_64: "linux-64"
+    aarch64: "linux-aarch64"
+    ppc64le: "linux-ppc64le"
+  Darwin:
+    x86_64: "osx-64"
+    arm64: "osx-arm64"
+  Windows:
+    x86_64: "win-64"

--- a/TerraformSlurmCluster/main.tf
+++ b/TerraformSlurmCluster/main.tf
@@ -1,5 +1,7 @@
 module "slurm_cluster" {
   source = "./modules/slurm_cluster"
+  
+  region		  = var.region
 
   key_pair                = var.key_pair
   compute_instances_count = var.compute_instances_count

--- a/TerraformSlurmCluster/modules/slurm_cluster/vars.tf
+++ b/TerraformSlurmCluster/modules/slurm_cluster/vars.tf
@@ -1,3 +1,8 @@
+variable "region" {
+  type = string
+  description = "OpenStack Region variable for deployment"
+}
+
 variable "os_image_id" {
   type = string
   description = "Operating system to use for the VMs."

--- a/TerraformSlurmCluster/modules/slurm_cluster/volume.tf
+++ b/TerraformSlurmCluster/modules/slurm_cluster/volume.tf
@@ -1,5 +1,5 @@
 resource "openstack_blockstorage_volume_v3" "nfs-ceph" {
-  region      = "RegionTwo"
+  region      = var.region
   name        = "nfs-ceph"
   size        = var.volume_size
   volume_type = var.volume_type

--- a/TerraformSlurmCluster/vars.tf
+++ b/TerraformSlurmCluster/vars.tf
@@ -1,3 +1,8 @@
+variable "region" {
+  type    = string
+  default = "RegionOne"
+}
+
 variable "key_pair" {
   type    = string
   default = "slurm"
@@ -5,22 +10,22 @@ variable "key_pair" {
 
 variable "ubuntu_jammy_image_id" {
   type = string
-  default = "5f5a9f1c-2666-4eeb-a58c-0339378176c2"
+  default = "c363d3de-7811-432f-8e5a-75206ece6dac"
 }
 
 variable "mini_flavor_id" {
   type = string
-  default = "0081036a-c935-4810-8044-d68b87f299db"
+  default = "7bea2f6b-ca8a-425f-8f42-ab540efba77a"
 }
 
 variable "slurm_flavor_id" {
   type = string
-  default = "8503f7d9-7307-4429-9576-d3e58ca16024"
+  default = "c20ceb66-ce9f-4488-ae57-981725b22f21"
 }
 
 variable "compute_instances_count" {
   type = number
-  default = 7
+  default = 3
 }
 
 variable "volume_size" {
@@ -35,7 +40,7 @@ variable "volume_type" {
 
 variable "ipv6_external_network" {
   type = string
-  default = "1f4c65ef-dd53-4d85-b2d0-1fd1a178522c"
+  default = "49c5cd87-ee9d-4a8e-9608-77eb9a46b583"
 }
 
 variable "slurm_subnet_cidr" {


### PR DESCRIPTION
Add micromamba installation to common playbook. Also add conda_env role to enable installation, creation and updating of conda environments using micromamba.
Small bug to add "region" var to vars files, main.tf and use this in volume creation.
Without this, region needs to be manually changed for the volume, which by default gets created in the wrong region and therefore cannot be mounted