### PR TITLE
Update ganesha.conf.j2 - remove NFSv3 protocol

### DIFF
--- a/AnsibleSlurmCluster/roles/slurm-controller/templates/ganesha.conf.j2
+++ b/AnsibleSlurmCluster/roles/slurm-controller/templates/ganesha.conf.j2
@@ -7,7 +7,7 @@ EXPORT
   Access_Type = RW;
   Squash = None;
   SecType = sys;
-  Protocols = 3,4;
+  Protocols = 4;
   FSAL
   {
     Name = VFS;


### PR DESCRIPTION
As per our discussion on Slack 09.04.2024:

It was related to ganeesha export config using  NFSv3 and NFSv4 in the protocols. Apparently, v3 is legacy and makes things difficult with portmapper. I ended up removing the v3 support from the ganeesha config and reloading the service 11:09
From ChatGPT:
:magnifying_glass: Here's What's Likely Happening: Ganesha supports NFSv3 and v4, but:
showmount uses NFSv3 + RPC portmapper.
You're exporting with Protocols = 3,4, which is good, but if your firewall is blocking RPC portmapper ports, then NFSv3 clients will fail (and tools like showmount won't work). :white_tick: Fix Steps
1. Preferred Option: Stick to NFSv4 Only NFSv4 does not use the portmapper, and is easier to firewall. Edit your export config to drop NFSv3 and use just v4: